### PR TITLE
chore: add issue and pull request templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+### ✍️ Descripción
+
+<!-- Por favor, incluye un resumen de los cambios y los *issues* relacionados, junto
+con una motivación y el contexto por el que se han hecho. -->
+
+Fixes # (issue)
+
+#### 🧑‍🔧 Tipo de cambio
+
+- [ ] *Bugfix* (cambios compatibles que arreglan un error)
+- [ ] Nueva característica (cambios compatibles que añaden funcionalidades)
+- [ ] Mejora de característica (cambios compatibles que mejoran funcionalidades ya existentes)
+- [ ] Cambio incompatible (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Este cambio requiere de una actualización de la documentación.
+
+#### 🧪 ¿Cómo se ha probado?
+
+<!-- Elimina las opciones que no sean relevantes. -->
+
+Por favor, describe las pruebas que has llevado a cabo para verificar la calidad de tus cambios.
+Asegúrate de explicar también cualquier configuración extra que debamos saber.
+
+- [ ] Test A
+- [ ] Test B
+
+#### 📃 Tareas
+
+<!-- Elimina las opciones que no sean relevantes. -->
+
+- [ ] El código sigue un estilo común y coherente
+- [ ] He revisado manualmente mi código
+- [ ] He añadido comentarios, especialmente en áreas difíciles de entender
+- [ ] He realizado los cambios correspondientes en la documentación
+- [ ] Mis cambios no generan nuevas advertencias al compilar
+- [ ] He seguido [la plantilla](https://github.com/us-ferferga/decide/blob/master/.gitmessage.txt) para realizar mis commits
+- [ ] He añadido tests automáticos que prueban que mi código es efectivo
+- [ ] Todos los cambios de los que este *Pull Request* depende ya están en la rama principal.

--- a/.github/workflows/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,65 @@
+name: 🪲 Reportar error
+description: Informar de un error o regresión en el uso. 
+labels: [bug]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ¡Gracias por tu interés en mejorar decide!
+
+        Antes de continuar, verifica que [no existe un reporte de error](https://github.com/us-ferferga/decide) que coincida con el tuyo.
+  - type: textarea
+    attributes:
+      label: ✍️ Descripción
+      description: Una descripción clara y concisa del problema.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 🚶Pasos para reproducir
+      description: Explica cómo podemos reproducirlo
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: ✅ Comportamiento esperado
+      description: Una descripción clara y concisa del comportamiento deseado.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 📃Registros
+      description: Si es relevante, proporciona registros (tanto del servidor como del cliente) que nos puedan servir para identificar el problema.
+      render: text
+  - type: textarea
+    attributes:
+      label: 📷 Capturas de pantalla
+      description: Si aplica, capturas de pantalla que ayuden a explicar el problema.
+  - type: dropdown
+    attributes:
+      label: 🖥️ Platforma del servidor
+      description: Plataforma en la que estás corriendo el backend de decide.
+      options:
+        - Linux
+        - Windows
+        - macOS
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: 🌐Navegador del cliente
+      description: Navegador con el que estás accediendo a decide.
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Edge
+        - Otro (Por favor, especifica cuál en la sección "contexto adicional")
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: ✨ Contexto adicional
+      description: Si lo crees necesario, proporciona otra información que pueda ser relevante.
+      render: text

--- a/.github/workflows/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,39 @@
+name: 💡 Sugerencias
+description: Proponer nuevas características Informar de un error o regresión en el uso. 
+labels: [enhancement]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ¡Gracias por tu interés en mejorar decide!
+
+        Antes de continuar, verifica que [no existe una propuesta](https://github.com/us-ferferga/decide) similar a la tuya.
+  - type: textarea
+    attributes:
+      label: ✍️ Descripción
+      description: Una descripción clara y concisa de lo que propones.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 🚶¿Cómo podemos llevarla a cabo?
+      description: Si se te ocurre como podemos gestionar y planificar la implementación de tu propuesta, por favor, descríbelo aquí.
+    validations:
+      required: false
+  - type: dropdown
+    attributes:
+      label: 🧩 Subsistema
+      description: Si conoces el(los) subsistema(s) que hay que modificar para llevar a cabo tu propuesta, selecciónalos aquí. Puedes ver [una lista](https://github.com/us-ferferga/decide/blob/master/doc/subsistemas.md)
+      multiple: true
+      options:
+        - Autenticacion
+        - Censo
+        - Votaciones
+        - Cabina de votación
+        - Almacenamiento de votos (cifrados)
+        - Recuento / MixNet
+        - Postprocesado
+        - Visualización de resultados
+    validations:
+      required: false

--- a/.github/workflows/ISSUE_TEMPLATE/config.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
### ✍️ Descripción

Crea plantillas para los *pull requests* e *issues*.

He proporcionado una base común para empezar a trabajar, ¿quizás en el futuro es necesario añadir una plantilla nueva que sea exclusivamente para la planificación y específica para nosotros?

#### 🧑‍🔧 Tipo de cambio

- [ ] 🪳 Corrección de errores (cambios compatibles que arreglan un error)
- [ ] 💡 Nueva característica (cambios compatibles que añaden funcionalidades)
- [ ] 🚀 Mejora de característica (cambios compatibles que mejoran funcionalidades ya existentes)
- [ ] ⚡ Cambio incompatible (correcciones o características que pueden hacer que funcionalidades actuales no funcionen como se espera)
- [X] 📄 Documentación

#### 📃 Tareas

<!-- Elimina las opciones que no sean relevantes. -->

- [x] El código sigue un estilo común y coherente
- [X] He revisado manualmente mi código
- [X] He realizado los cambios correspondientes en la documentación
- [X] Mis cambios no generan nuevas advertencias al compilar
- [X] He seguido [la plantilla](https://github.com/us-ferferga/decide/blob/master/.gitmessage.txt) para realizar mis commits
- [X] Todos los cambios de los que este *Pull Request* depende ya están en la rama principal.
