### PR TITLE
feat(devcontainer): create devcontainer definition

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+  "name": "Decide Codespace",
+  "image": "python:latest",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "dockerDashComposeVersion": "v2"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {},
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers-contrib/features/apt-packages:1": {
+      "preserve_apt_list": false,
+      "packages": ["postgresql", "libpq-dev", "htop"]
+    }
+  },
+  "postCreateCommand": {
+    "npm": "npm ci --workspaces",
+    "pip": "pip install -r requirements.txt",
+    "use-bash": "rm -rf /bin/sh && ln -s /bin/bash /bin/sh",
+    "git-editor": "git config --global core.editor 'code --wait'",
+    "git-template": "git config commit.template .gitmessage.txt",
+    "postunpack": "service postgresql start && .devcontainer/postunpack.sh"
+  },
+  "postAttachCommand": {
+    "extensions": "cat .vscode/extensions.json | jq -r .recommendations[] | xargs -n 1 code --install-extension",
+    "postgres": "service postgresql start"
+  },
+  "hostRequirements": { "cpus": 4, "memory": "8gb" }
+}

--- a/.devcontainer/postunpack.sh
+++ b/.devcontainer/postunpack.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+## This script finishes the installation of the devcontainer
+##
+## Currently it just sets up the database user using decide's local_settings.py default values
+## If you want to modify those credentials,
+## you can alter them at any time manually: https://stackoverflow.com/questions/12720967/how-can-i-change-a-postgresql-user-password
+
+su - postgres <<EOSQL
+psql -c "create user decide with password 'decide'"
+psql -c "create database decide owner decide"
+EOSQL
+
+echo "127.0.0.1 db" >> /etc/hosts

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "ms-python.python"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true,
-        "source.organizeImports": false
+        "source.fixAll.eslint": "always",
+        "source.organizeImports": "always"
     },
     "[javascript]": {
         "editor.defaultFormatter": "dbaeumer.vscode-eslint"


### PR DESCRIPTION
### ✍️ Descripción

Crea una definición de ``devcontainer`` completa para poder lanzar un entorno de desarrollo con Decide listo para funcionar usando Devcontainers, que funciona tanto en local como en la nube con GitHub Codespaces.

- Instala las dependencias
- Configura la base de datos con el usuario y claves por defecto
- Configura la plantilla de los commits por defecto, de forma que salga también incluso en el panel de VSCode
- Configura también npm y el desarrollo del frontend del módulo `booth`

Lo único que hay que hacer tras lanzar el entorno es ``manage.py migrate`` ``manage.py createsuperuser`` y ``manage.py runserver``, el resto de pasos ya están dentro.
El contenedor también incluye soporte para Docker in Docker, de forma que se puedan probar las imágenes de Docker también

Fixes #26

#### 🧑‍🔧 Tipo de cambio

- [ ] *Bugfix* (cambios compatibles que arreglan un error)
- [X] Nueva característica (cambios compatibles que añaden funcionalidades)
- [X] Mejora de característica (cambios compatibles que mejoran funcionalidades ya existentes)
- [ ] Cambio incompatible (arreglo o característica que cambia radicalmente el funcionamiento esperado)
- [X] Este cambio requiere de una actualización de la documentación.

#### 🧪 ¿Cómo se ha probado?

Manualmente, ejecutándolo en GitHub Codespaces tras el último commit subido a esta rama.

#### 📃 Tareas

<!-- Elimina las opciones que no sean relevantes. -->

- [X] El código sigue un estilo común y coherente
- [X] He revisado manualmente mi código
- [X] He añadido comentarios, especialmente en áreas difíciles de entender
- [ ] He realizado los cambios correspondientes en la documentación
- [X] Mis cambios no generan nuevas advertencias al compilar
- [X] He seguido [la plantilla](https://github.com/us-ferferga/decide/blob/master/.gitmessage.txt) para realizar mis commits
- [ ] He añadido tests automáticos que prueban que mi código es efectivo
- [X] Todos los cambios de los que este *Pull Request* depende ya están en la rama principal.
